### PR TITLE
Add a wrapper for FB_ACTIVATE_NOW ioctl to force refresh the framebuffer

### DIFF
--- a/include/tfblib/tfb_errors.h
+++ b/include/tfblib/tfb_errors.h
@@ -64,6 +64,9 @@
 /// Unable to find a font matching the criteria
 #define TFB_ERR_FONT_NOT_FOUND           15
 
+/// Unable to flush the framebuffer with ioctl()
+#define TFB_ERR_FB_FLUSH_IOCTL_FAILED 16
+
 /**
  * Returns a human-readable error message.
  *

--- a/include/tfblib/tfblib.h
+++ b/include/tfblib/tfblib.h
@@ -599,6 +599,18 @@ void tfb_flush_rect(int x, int y, int w, int h);
  */
 void tfb_flush_window(void);
 
+/**
+ * Flush the framebuffer, causing it to update. This is different
+ * to tfb_flush_window() as it doesn't deal with double_buffering,
+ * rather it handles the case where the framebuffer has to be "ACTIVATED".
+ * 
+ * @return #TFB_SUCCESS on success or #TFB_ERR_FB_FLUSH_IOCTL_FAILED
+ *    on failure.
+ * 
+ * @see tfb_flush_window
+ */
+int tfb_flush_fb(void);
+
 #include "tfb_inline_funcs.h" // internal header
 
 /* undef the the convenience types defined above */

--- a/src/fb.c
+++ b/src/fb.c
@@ -214,6 +214,16 @@ void tfb_flush_window(void)
    tfb_flush_rect(0, 0, __fb_win_w, __fb_win_h);
 }
 
+int tfb_flush_fb(void)
+{ 
+   __fbi.activate |= FB_ACTIVATE_NOW | FB_ACTIVATE_FORCE;
+   if(ioctl(fbfd, FBIOPUT_VSCREENINFO, &__fbi) < 0) {
+      return TFB_ERR_FB_FLUSH_IOCTL_FAILED;
+   }
+
+   return TFB_SUCCESS;
+}
+
 /*
  * ----------------------------------------------------------------------------
  *


### PR DESCRIPTION
Some framebuffer devices don't seem to want to actually render what you give them until this IOCTL is called, add a simple wrapper for it.