### PR TITLE
[text] add tfb_draw_string_scaled_wrapped

### DIFF
--- a/include/tfblib/tfblib.h
+++ b/include/tfblib/tfblib.h
@@ -497,6 +497,27 @@ void tfb_draw_char_scaled(int x, int y, u32 fg, u32 bg,
                           int xscale, int yscale, u8 c);
 
 /**
+ * line tfb_draw_char_scaled but also line wraps at (wrap_col), and
+ * newlines.
+ *
+ * @param[in]  x        Window-relative X coordinate of text's position
+ * @param[in]  y        Window-relative Y coordinate of text's position
+ * @param[in]  fg       Foreground text color
+ * @param[in]  bg       Background text color
+ * @param[in]  xscale   Horizontal scale
+ * @param[in]  yscale   Vertical scale
+ * @param[in]  wrap_col Number of characters to print before wrapping
+ * @param[in]  s        A char pointer to the string
+ *
+ * Like tfb_draw_string(), but scaled. @see tfb_draw_char_scaled().
+ *
+ * \see tfb_draw_char_scaled
+ */
+void tfb_draw_string_scaled_wrapped(int x, int y, u32 fg, u32 bg,
+                                    int xscale, int yscale, u32 wrap_col,
+                                    const char *s);
+
+/**
  * Draw a NUL-terminated string on-screen at (x, y) scaled by (xscale, yscale)
  *
  * @param[in]  x        Window-relative X coordinate of text's position

--- a/src/text.c
+++ b/src/text.c
@@ -306,6 +306,29 @@ void tfb_draw_string(int x, int y, u32 fg_color, u32 bg_color, const char *s)
    }
 }
 
+void tfb_draw_string_scaled_wrapped(int x, int y,
+                                    u32 fg, u32 bg,
+                                    int xscale, int yscale, u32 wrap_col,
+                                    const char *s)
+{
+   int base_x = x;
+   if (!curr_font) {
+      fprintf(stderr, "[tfblib] ERROR: no font currently selected\n");
+      return;
+   }
+
+   const int xs = xscale > 0 ? xscale : -xscale;
+
+   for (int i = 0; *s; s++, x += xs * curr_font_w, i++) {
+      if ((*s == '\n' && *++s) || (wrap_col > 0 && i % wrap_col == 0))
+      {
+         y += curr_font_h * yscale + 2;
+         x = base_x;
+      }
+      tfb_draw_char_scaled(x, y, fg, bg, xscale, yscale, *s);
+   }
+}
+
 void tfb_draw_string_scaled(int x, int y,
                             u32 fg, u32 bg,
                             int xscale, int yscale, const char *s)


### PR DESCRIPTION
This function is like tfb_draw_string_scaled but supports wrapping on
some arbitrary number of columns as well as on newlines.