### PR TITLE
[cmake] install and generate pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,12 @@ include(ExternalProject)
 
 if (NOT "${CMAKE_PROJECT_NAME}" STREQUAL "tilck")
 
-   project(tfblib C)
+   project(tfblib
+      LANGUAGES C
+      HOMEPAGE_URL https://github.com/vvaltchev/tfblib
+      DESCRIPTION "A Tiny Linux Framebuffer Library"
+      VERSION "0.1"
+      )
 
    set(CMAKE_C_FLAGS_DEBUG "-g")
    set(CMAKE_C_FLAGS_MINSIZEREL "-Os")
@@ -110,4 +115,15 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "tilck")
    tilck_add_extra_app(${CMAKE_CURRENT_BINARY_DIR}/examples/fb_keyinput)
    tilck_add_extra_app(${CMAKE_CURRENT_BINARY_DIR}/examples/fb_text)
    tilck_add_extra_app(${CMAKE_CURRENT_BINARY_DIR}/examples/fb_tetris)
+else()
+   # For populating pkg-config template
+   set(target1 tfb)
+   configure_file(tfblib.pc.in tfblib.pc @ONLY)
+
+   install(TARGETS tfb DESTINATION lib)
+   install (
+     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+     DESTINATION include
+     FILES_MATCHING PATTERN "*.h")
+   install(FILES ${CMAKE_BINARY_DIR}/tfblib.pc DESTINATION lib/pkgconfig)
 endif()

--- a/tfblib.pc.in
+++ b/tfblib.pc.in
@@ -1,0 +1,19 @@
+# this template is filled-in by CMake `configure_file(... @ONLY)`
+# the `@....@` are filled in by CMake configure_file(),
+# from variables set in your CMakeLists.txt or by CMake itself
+#
+# Good tutoral for understanding .pc files:
+# https://people.freedesktop.org/~dbn/pkg-config-guide.html
+
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: @CMAKE_PROJECT_DESCRIPTION@
+URL: @CMAKE_PROJECT_HOMEPAGE_URL@
+Requires:
+Version: @PROJECT_VERSION@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -l@target1@


### PR DESCRIPTION
Add support for make install and generate a pkgconfig to allow tfblib to
be packaged more easily. I'd like to package tfblib in Alpine so that we can use it for driving the postmarketOS splash screen: https://git.sr.ht/~calebccff/pbsplash (early/wip code). These changes make it easy to package, install and use tfblib as a standard system library, so it doesn't have to be included as a submodule in other projects.