### PR TITLE
Expose phys dimensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if (NOT "${CMAKE_PROJECT_NAME}" STREQUAL "tilck")
       LANGUAGES C
       HOMEPAGE_URL https://github.com/vvaltchev/tfblib
       DESCRIPTION "A Tiny Linux Framebuffer Library"
-      VERSION "0.1"
+      VERSION "0.1.1"
       )
 
    set(CMAKE_C_FLAGS_DEBUG "-g")

--- a/include/tfblib/tfblib.h
+++ b/include/tfblib/tfblib.h
@@ -580,6 +580,20 @@ inline u32 tfb_screen_width(void);
 inline u32 tfb_screen_height(void);
 
 /**
+ * Get screen's physical width in mm
+ *
+ * @return  the width of the screen in mm
+ */
+u32 tfb_screen_width_mm(void);
+
+/**
+ * Get screen's physical height in mm
+ *
+ * @return  the height of the screen in mm
+ */
+u32 tfb_screen_height_mm(void);
+
+/**
  * Get current window's width
  *
  * @return  the width of the current window
@@ -624,10 +638,10 @@ void tfb_flush_window(void);
  * Flush the framebuffer, causing it to update. This is different
  * to tfb_flush_window() as it doesn't deal with double_buffering,
  * rather it handles the case where the framebuffer has to be "ACTIVATED".
- * 
+ *
  * @return #TFB_SUCCESS on success or #TFB_ERR_FB_FLUSH_IOCTL_FAILED
  *    on failure.
- * 
+ *
  * @see tfb_flush_window
  */
 int tfb_flush_fb(void);

--- a/src/fb.c
+++ b/src/fb.c
@@ -215,7 +215,7 @@ void tfb_flush_window(void)
 }
 
 int tfb_flush_fb(void)
-{ 
+{
    __fbi.activate |= FB_ACTIVATE_NOW | FB_ACTIVATE_FORCE;
    if(ioctl(fbfd, FBIOPUT_VSCREENINFO, &__fbi) < 0) {
       return TFB_ERR_FB_FLUSH_IOCTL_FAILED;
@@ -223,6 +223,9 @@ int tfb_flush_fb(void)
 
    return TFB_SUCCESS;
 }
+
+u32 tfb_screen_width_mm(void) { return __fbi.width; }
+u32 tfb_screen_height_mm(void) { return __fbi.height; }
 
 /*
  * ----------------------------------------------------------------------------


### PR DESCRIPTION
Add some new methods to expose the physical width and height of the display. For mobile devices this is usually hardcoded in the panel driver, for external displays this is exposed via EDID.

This is useful to let us scale the content based on the physical size of the display, e.g. for displaying a boot splash logo, on a phone we want the logo to occupy most of the display width, on a laptop or tablet this looks a bit overbearing.

P.S could you create a git tag to match the cmake version? This makes packaging a little easier (https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/29853)