### PR TITLE
Adding preliminary 16-bit depth support to tfblib

### DIFF
--- a/include/tfblib/tfb_errors.h
+++ b/include/tfblib/tfb_errors.h
@@ -36,7 +36,7 @@
 /**
  * Unsupported video mode
  *
- * \note Currently the library supports only 32-bit color modes.
+ * \note Currently the library supports only 16-bit and 32-bit color modes.
  */
 #define TFB_ERR_UNSUPPORTED_VIDEO_MODE_DEPTH 7
 

--- a/include/tfblib/tfb_errors.h
+++ b/include/tfblib/tfb_errors.h
@@ -38,7 +38,7 @@
  *
  * \note Currently the library supports only 32-bit color modes.
  */
-#define TFB_ERR_UNSUPPORTED_VIDEO_MODE    7
+#define TFB_ERR_UNSUPPORTED_VIDEO_MODE_DEPTH 7
 
 /// The supplied font_id is invalid
 #define TFB_ERR_INVALID_FONT_ID           8
@@ -66,6 +66,9 @@
 
 /// Unable to flush the framebuffer with ioctl()
 #define TFB_ERR_FB_FLUSH_IOCTL_FAILED 16
+
+/// MSB is to the right in the colour byte
+#define TFB_ERR_UNSUPPORTED_VIDEO_MODE_MSB 17
 
 /**
  * Returns a human-readable error message.

--- a/include/tfblib/tfb_inline_funcs.h
+++ b/include/tfblib/tfb_inline_funcs.h
@@ -35,16 +35,19 @@ extern int __fb_depth;
 
 inline u32 tfb_make_color(u8 r, u8 g, u8 b)
 {
-   return ((r << __fb_r_pos) & __fb_r_mask) |
-          ((g << __fb_g_pos) & __fb_g_mask) |
-          ((b << __fb_b_pos) & __fb_b_mask);
-}
-
-inline u16 tfb_clip_32_to_16(u32 col)
-{
-   return ((0x0000ff & col) >> 3) |
-          ((0x00ff00 & col) >> 13)|
-          ((0xff0000 & col) >> 23);
+   if(__fb_depth == 32)
+   {
+      return ((r << __fb_r_pos) & __fb_r_mask) |
+             ((g << __fb_g_pos) & __fb_g_mask) |
+             ((b << __fb_b_pos) & __fb_b_mask);
+   }
+   else
+   {
+      return 0xffff &
+             (((r << __fb_r_pos) & __fb_r_mask) |
+              ((g << __fb_g_pos) & __fb_g_mask) |
+              ((b << __fb_b_pos) & __fb_b_mask));
+   }
 }
 
 inline void tfb_draw_pixel(int x, int y, u32 color)
@@ -56,7 +59,10 @@ inline void tfb_draw_pixel(int x, int y, u32 color)
    {
       case 16:
          if ((u32)x < (u32)__fb_win_end_x && (u32)y < (u32)__fb_win_end_y)
-            ((volatile u16 *)__fb_buffer)[x + y * __fb_pitch_div2] = (u16)color;
+            ((volatile u16 *)__fb_buffer)[x + y * __fb_pitch_div2] =
+                  ((0x0000ff & color) >> 3) |
+                  ((0x00ff00 & color) >> 13)|
+                  ((0xff0000 & color) >> 23);
          break;
       case 32:
          if ((u32)x < (u32)__fb_win_end_x && (u32)y < (u32)__fb_win_end_y)

--- a/include/tfblib/tfb_inline_funcs.h
+++ b/include/tfblib/tfb_inline_funcs.h
@@ -30,6 +30,7 @@ extern u8 __fb_b_mask_size;
 extern u8 __fb_r_pos;
 extern u8 __fb_g_pos;
 extern u8 __fb_b_pos;
+extern int __fb_depth;
 
 inline u32 tfb_make_color(u8 r, u8 g, u8 b)
 {
@@ -38,13 +39,29 @@ inline u32 tfb_make_color(u8 r, u8 g, u8 b)
           ((b << __fb_b_pos) & __fb_b_mask);
 }
 
+inline u16 tfb_clip_32_to_16(u32 col)
+{
+   return ((0x0000ff & col) >> 3) |
+          ((0x00ff00 & col) >> 13)|
+          ((0xff0000 & col) >> 23);
+}
+
 inline void tfb_draw_pixel(int x, int y, u32 color)
 {
    x += __fb_off_x;
    y += __fb_off_y;
 
-   if ((u32)x < (u32)__fb_win_end_x && (u32)y < (u32)__fb_win_end_y)
-      ((volatile u32 *)__fb_buffer)[x + y * __fb_pitch_div4] = color;
+   switch (__fb_depth)
+   {
+      case 16:
+         break;
+      case 32:
+         if ((u32)x < (u32)__fb_win_end_x && (u32)y < (u32)__fb_win_end_y)
+         ((volatile u32 *)__fb_buffer)[x + y * __fb_pitch_div4] = color;
+         break;
+      default:
+         break;
+   }
 }
 
 inline u32 tfb_screen_width(void) { return __fb_screen_w; }

--- a/include/tfblib/tfb_inline_funcs.h
+++ b/include/tfblib/tfb_inline_funcs.h
@@ -10,6 +10,7 @@ extern int __fb_screen_w;
 extern int __fb_screen_h;
 extern size_t __fb_size;
 extern size_t __fb_pitch;
+extern size_t __fb_pitch_div2;
 extern size_t __fb_pitch_div4; /* see the comment in drawing.c */
 
 /* Window-related variables */
@@ -54,10 +55,12 @@ inline void tfb_draw_pixel(int x, int y, u32 color)
    switch (__fb_depth)
    {
       case 16:
+         if ((u32)x < (u32)__fb_win_end_x && (u32)y < (u32)__fb_win_end_y)
+            ((volatile u16 *)__fb_buffer)[x + y * __fb_pitch_div2] = (u16)color;
          break;
       case 32:
          if ((u32)x < (u32)__fb_win_end_x && (u32)y < (u32)__fb_win_end_y)
-         ((volatile u32 *)__fb_buffer)[x + y * __fb_pitch_div4] = color;
+            ((volatile u32 *)__fb_buffer)[x + y * __fb_pitch_div4] = color;
          break;
       default:
          break;

--- a/include/tfblib/tfb_inline_funcs.h
+++ b/include/tfblib/tfb_inline_funcs.h
@@ -35,19 +35,16 @@ extern int __fb_depth;
 
 inline u32 tfb_make_color(u8 r, u8 g, u8 b)
 {
-   if(__fb_depth == 32)
-   {
-      return ((r << __fb_r_pos) & __fb_r_mask) |
-             ((g << __fb_g_pos) & __fb_g_mask) |
-             ((b << __fb_b_pos) & __fb_b_mask);
-   }
-   else
-   {
-      return 0xffff &
-             (((r << __fb_r_pos) & __fb_r_mask) |
-              ((g << __fb_g_pos) & __fb_g_mask) |
-              ((b << __fb_b_pos) & __fb_b_mask));
-   }
+   return ((r << __fb_r_pos) & __fb_r_mask) |
+          ((g << __fb_g_pos) & __fb_g_mask) |
+          ((b << __fb_b_pos) & __fb_b_mask);
+}
+
+inline u16 tfb_clip_32_to_16(u32 col)
+{
+   return ((0x0000ff & col) >> 3) |
+          ((0x00ff00 & col) >> 13)|
+          ((0xff0000 & col) >> 23);
 }
 
 inline void tfb_draw_pixel(int x, int y, u32 color)
@@ -59,10 +56,7 @@ inline void tfb_draw_pixel(int x, int y, u32 color)
    {
       case 16:
          if ((u32)x < (u32)__fb_win_end_x && (u32)y < (u32)__fb_win_end_y)
-            ((volatile u16 *)__fb_buffer)[x + y * __fb_pitch_div2] =
-                  ((0x0000ff & color) >> 3) |
-                  ((0x00ff00 & color) >> 13)|
-                  ((0xff0000 & color) >> 23);
+            ((volatile u16 *)__fb_buffer)[x + y * __fb_pitch_div2] = (u16)color;
          break;
       case 32:
          if ((u32)x < (u32)__fb_win_end_x && (u32)y < (u32)__fb_win_end_y)

--- a/include/tfblib/tfb_inline_funcs.h
+++ b/include/tfblib/tfb_inline_funcs.h
@@ -35,16 +35,13 @@ extern int __fb_depth;
 
 inline u32 tfb_make_color(u8 r, u8 g, u8 b)
 {
+   r = r >> (8 - __fb_r_mask_size);
+   g = g >> (8 - __fb_g_mask_size);
+   b = b >> (8 - __fb_b_mask_size);
+
    return ((r << __fb_r_pos) & __fb_r_mask) |
           ((g << __fb_g_pos) & __fb_g_mask) |
           ((b << __fb_b_pos) & __fb_b_mask);
-}
-
-inline u16 tfb_clip_32_to_16(u32 col)
-{
-   return ((0x0000ff & col) >> 3) |
-          ((0x00ff00 & col) >> 13)|
-          ((0xff0000 & col) >> 23);
 }
 
 inline void tfb_draw_pixel(int x, int y, u32 color)

--- a/include/tfblib/tfblib.h
+++ b/include/tfblib/tfblib.h
@@ -653,4 +653,5 @@ int tfb_flush_fb(void);
 
 /* undef the the convenience types defined above */
 #undef u8
+#undef u16
 #undef u32

--- a/include/tfblib/tfblib.h
+++ b/include/tfblib/tfblib.h
@@ -18,6 +18,9 @@
 #define u8 uint8_t
 
 /// Convenience macro used to shorten the signatures. Undefined at the end.
+#define u16 uint16_t
+
+/// Convenience macro used to shorten the signatures. Undefined at the end.
 #define u32 uint32_t
 
 /*

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -87,7 +87,7 @@ void tfb_draw_hline(int x, int y, int len, u32 color)
       return;
 
    len = MIN(len, MAX(0, (int)__fb_win_end_x - x));
-   memset_var(__fb_buffer + y * __fb_pitch + (x << 2), color, len, __fb_depth);
+   memset_var(__fb_buffer + y * __fb_pitch + (x << (__fb_depth >> 4)), color, len, __fb_depth);
 }
 
 void tfb_draw_vline(int x, int y, int len, u32 color)
@@ -123,8 +123,6 @@ void tfb_draw_vline(int x, int y, int len, u32 color)
       for (; y < yend; y++, buf += __fb_pitch_div4)
          *buf = color;
    }
-
-   
 }
 
 void tfb_fill_rect(int x, int y, int w, int h, u32 color)
@@ -161,7 +159,7 @@ void tfb_fill_rect(int x, int y, int w, int h, u32 color)
    w = MIN(w, MAX(0, (int)__fb_win_end_x - x));
    yend = MIN(y + h, __fb_win_end_y);
 
-   dest = __fb_buffer + y * __fb_pitch + (x << 2);
+   dest = __fb_buffer + y * __fb_pitch + (x << (__fb_depth >> 4));
 
    for (u32 cy = y; cy < yend; cy++, dest += __fb_pitch)
       memset_var(dest, color, w, __fb_depth);

--- a/src/drawing.c
+++ b/src/drawing.c
@@ -60,7 +60,7 @@ int tfb_set_center_window_size(u32 w, u32 h)
 void tfb_clear_screen(u32 color)
 {
    if (__fb_pitch == (u32) 4 * __fb_screen_w) {
-      memset_var(__fb_buffer, color, __fb_size >> 2, __fb_depth);
+      memset_N(__fb_buffer, color, __fb_size >> 2, __fb_depth);
       return;
    }
 
@@ -87,7 +87,8 @@ void tfb_draw_hline(int x, int y, int len, u32 color)
       return;
 
    len = MIN(len, MAX(0, (int)__fb_win_end_x - x));
-   memset_var(__fb_buffer + y * __fb_pitch + (x << (__fb_depth >> 4)), color, len, __fb_depth);
+   memset_N(__fb_buffer + y * __fb_pitch + (x << (__fb_depth >> 4)), 
+             color, len, __fb_depth);
 }
 
 void tfb_draw_vline(int x, int y, int len, u32 color)
@@ -107,16 +108,13 @@ void tfb_draw_vline(int x, int y, int len, u32 color)
 
    yend = MIN(y + len, __fb_win_end_y);
 
-   if(__fb_depth == 16)
-   {
+   if(__fb_depth == 16) {
       volatile u16 *buf =
          ((volatile u16 *) __fb_buffer) + y * __fb_pitch_div2 + x;
 
       for (; y < yend; y++, buf += __fb_pitch_div2)
          *buf = (u16)color;
-   }
-   else
-   {
+   } else {
       volatile u32 *buf =
          ((volatile u32 *) __fb_buffer) + y * __fb_pitch_div4 + x;
 
@@ -162,7 +160,7 @@ void tfb_fill_rect(int x, int y, int w, int h, u32 color)
    dest = __fb_buffer + y * __fb_pitch + (x << (__fb_depth >> 4));
 
    for (u32 cy = y; cy < yend; cy++, dest += __fb_pitch)
-      memset_var(dest, color, w, __fb_depth);
+      memset_N(dest, color, w, __fb_depth);
 }
 
 void tfb_draw_rect(int x, int y, int w, int h, u32 color)

--- a/src/errors.c
+++ b/src/errors.c
@@ -12,7 +12,7 @@ static const char *error_msgs[] =
    /*  4 */    "Unable to set TTY in graphic mode",
    /*  5 */    "Unable to mmap the framebuffer",
    /*  6 */    "Invalid window position/size",
-   /*  7 */    "Unsupported video mode",
+   /*  7 */    "Unsupported video mode: wrong color depth",
    /*  8 */    "Invalid font_id",
    /*  9 */    "Unable to open/read/load the font file",
    /* 10 */    "Out of memory",
@@ -22,6 +22,7 @@ static const char *error_msgs[] =
    /* 14 */    "Unable to set a keyboard input paramater with ioctl()",
    /* 15 */    "Unable to find a font matching the criteria",
    /* 16 */    "Unable to flush the framebuffer with ioctl()",
+   /* 17 */    "Unsupported video mode: MSB is to the right"
 };
 
 const char *tfb_strerror(int error_code)

--- a/src/fb.c
+++ b/src/fb.c
@@ -81,12 +81,12 @@ int tfb_acquire_fb(u32 flags, const char *fb_device, const char *tty_device)
    __fb_pitch_div4 = __fb_pitch >> 2;
 
    if (__fbi.bits_per_pixel != 32) {
-      ret = TFB_ERR_UNSUPPORTED_VIDEO_MODE;
+      ret = TFB_ERR_UNSUPPORTED_VIDEO_MODE_DEPTH;
       goto out;
    }
 
    if (__fbi.red.msb_right || __fbi.green.msb_right || __fbi.blue.msb_right) {
-      ret = TFB_ERR_UNSUPPORTED_VIDEO_MODE;
+      ret = TFB_ERR_UNSUPPORTED_VIDEO_MODE_MSB;
       goto out;
    }
 

--- a/src/fb.c
+++ b/src/fb.c
@@ -205,10 +205,10 @@ void tfb_flush_rect(int x, int y, int w, int h)
    w = MIN(w, MAX(0, __fb_win_end_x - x));
    yend = MIN(y + h, __fb_win_end_y);
 
-   size_t offset = y * __fb_pitch + (x << 2);
+   size_t offset = y * __fb_pitch + (x << (__fb_depth >> 4));
    void *dest = __fb_real_buffer + offset;
    void *src = __fb_buffer + offset;
-   u32 rect_pitch = w << 2;
+   u32 rect_pitch = w << (__fb_depth >> 4);
 
    for (int cy = y; cy < yend; cy++, src += __fb_pitch, dest += __fb_pitch)
       memcpy(dest, src, rect_pitch);

--- a/src/fb.c
+++ b/src/fb.c
@@ -80,6 +80,7 @@ int tfb_acquire_fb(u32 flags, const char *fb_device, const char *tty_device)
 
    __fb_pitch = fb_fixinfo.line_length;
    __fb_size = __fb_pitch * __fbi.yres;
+   __fb_pitch_div2 = __fb_pitch >> 1;
    __fb_pitch_div4 = __fb_pitch >> 2;
 
    if ((__fbi.bits_per_pixel != 32)/* && (__fbi.bits_per_pixel != 16)*/) {

--- a/src/fb.c
+++ b/src/fb.c
@@ -83,7 +83,7 @@ int tfb_acquire_fb(u32 flags, const char *fb_device, const char *tty_device)
    __fb_pitch_div2 = __fb_pitch >> 1;
    __fb_pitch_div4 = __fb_pitch >> 2;
 
-   if ((__fbi.bits_per_pixel != 32)/* && (__fbi.bits_per_pixel != 16)*/) {
+   if ((__fbi.bits_per_pixel != 32) && (__fbi.bits_per_pixel != 16)) {
       ret = TFB_ERR_UNSUPPORTED_VIDEO_MODE_DEPTH;
       goto out;
    }

--- a/src/fb.c
+++ b/src/fb.c
@@ -27,6 +27,8 @@ int __tfb_ttyfd = -1;
 
 static int fbfd = -1;
 
+int __fb_depth = 0;
+
 static void tfb_init_colors(void);
 
 int tfb_set_window(u32 x, u32 y, u32 w, u32 h)
@@ -80,10 +82,12 @@ int tfb_acquire_fb(u32 flags, const char *fb_device, const char *tty_device)
    __fb_size = __fb_pitch * __fbi.yres;
    __fb_pitch_div4 = __fb_pitch >> 2;
 
-   if (__fbi.bits_per_pixel != 32) {
+   if ((__fbi.bits_per_pixel != 32)/* && (__fbi.bits_per_pixel != 16)*/) {
       ret = TFB_ERR_UNSUPPORTED_VIDEO_MODE_DEPTH;
       goto out;
    }
+
+   __fb_depth = __fbi.bits_per_pixel;
 
    if (__fbi.red.msb_right || __fbi.green.msb_right || __fbi.blue.msb_right) {
       ret = TFB_ERR_UNSUPPORTED_VIDEO_MODE_MSB;

--- a/src/text.c
+++ b/src/text.c
@@ -233,14 +233,12 @@ void tfb_draw_char(int x, int y, u32 fg_color, u32 bg_color, u8 c)
     */
 
    if (curr_font_w_bytes == 1)
-
       for (u32 row = y; row < (y + curr_font_h); row++) {
          draw_char_partial(0);
          data += curr_font_w_bytes;
       }
 
    else if (curr_font_w_bytes == 2)
-
       for (u32 row = y; row < (y + curr_font_h); row++) {
          draw_char_partial(0);
          draw_char_partial(1);
@@ -248,13 +246,10 @@ void tfb_draw_char(int x, int y, u32 fg_color, u32 bg_color, u8 c)
       }
 
    else
-
       for (u32 row = y; row < (y + curr_font_h); row++) {
-
          for (u32 b = 0; b < curr_font_w_bytes; b++) {
             draw_char_partial(b);
          }
-
          data += curr_font_w_bytes;
       }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -58,9 +58,9 @@ static inline void *memset16(void *s, u16 val, size_t n)
 /*
  * Choose between memset types based on depth
  */
-static inline void *memset_var(void *s, u32 val, size_t n, int depth)
+static inline void *memset_N(void *s, u32 val, size_t n, int bits)
 {
-   switch(depth)
+   switch(bits)
    {
       case 16:
          return memset16(s, val, n);
@@ -69,6 +69,6 @@ static inline void *memset_var(void *s, u32 val, size_t n, int depth)
          return memset32(s, val, n);
          break;
       default:
-         return (void*)0;
+         return NULL;
    }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,7 +22,6 @@ typedef uint8_t u8;
 typedef uint16_t u16;
 typedef uint32_t u32;
 
-
 /*
  * Set 'n' 32-bit elems pointed by 's' to 'val'.
  */
@@ -41,6 +40,17 @@ static inline void *memset32(void *s, u32 val, size_t n)
       ((volatile u32 *)s)[i] = val;
 
 #endif
+
+   return s;
+}
+
+/*
+ * Set 'n' 16-bit elems pointed by 's' to 'val'.
+ */
+static inline void *memset16(void *s, u16 val, size_t n)
+{
+   for(size_t i = 0; i < n; i++)
+      ((volatile u16 *)s)[i] = val;
 
    return s;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -54,3 +54,21 @@ static inline void *memset16(void *s, u16 val, size_t n)
 
    return s;
 }
+
+/*
+ * Choose between memset types based on depth
+ */
+static inline void *memset_var(void *s, u32 val, size_t n, int depth)
+{
+   switch(depth)
+   {
+      case 16:
+         return memset16(s, val, n);
+         break;
+      case 32:
+         return memset32(s, val, n);
+         break;
+      default:
+         return (void*)0;
+   }
+}


### PR DESCRIPTION
This set of commits adds preliminary 16bpp support to tfblib with minimal code changes; adds two new functions to support variable width `memset`. It builds all the examples without errors and runs them more-or-less fine: `fb_tetris` is now twice as large as it's supposed to be, but otherwise everything else seems to work like on 32bpp mode. 

Tested on a Raspberry Pi 400 running Alpine 3.23 on kernel version 6.12 using the `vc4-kms-v3d` driver that sets the framebuffer to 1920x1080@16bpp by default. It was built using both GCC 11.2 and 15.2 without issue. Tested only on examples in repo and slight test modifications to them, no personal code examples tested.

It should be comparable performance-wise, but might suffer very slightly from
* `memset32()` calls replaced with `memset_var()` which dispatches the call to either `memset32()` or the newly-added `memset16()` based on colour depth. This could probably be replaced by a function pointer that is set to either `memset32()` or `memset16()` at setup-time, but I haven't done this (yet?)
* `tfb_make_color()` now has three bitshifts that are unavoidable since 16bpp has weird arrangements of colour values (either RGB565 or ARGB1555, both of which should be handled cleanly by the new variant)
* several new bitshifts and conditionals all over the place 

Conversely, it should also benefit slightly from having to do half as much memory transfering during memset operations. Both of these should nonetheless not be noticeable.

Attaching a photo of the mandelbrot sample as proof of concept

![20251209_0210212](https://github.com/user-attachments/assets/4060173a-ca0b-4eaf-8d4b-a43cad8d0323)
